### PR TITLE
fix temporary file could not open again in windows

### DIFF
--- a/src/uv2conda/uv.py
+++ b/src/uv2conda/uv.py
@@ -56,17 +56,18 @@ def get_pip_requirements_from_project_dir(
     uv_args: list[str] | None = None,
     out_requirements_path: Path | None = None,
 ) -> PipRequirements:
+    logger.error("test")
     if out_requirements_path is None:
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".txt", delete_on_close=False
         ) as f:
             requirements_path = Path(f.name)
-            requirements = PipRequirements.from_requirements_file(requirements_path)
         write_requirements_file_from_project_dir(
             project_dir,
             requirements_path,
             extra_args=uv_args,
         )
+        requirements = PipRequirements.from_requirements_file(requirements_path)
 
     else:
         write_requirements_file_from_project_dir(

--- a/src/uv2conda/uv.py
+++ b/src/uv2conda/uv.py
@@ -57,14 +57,17 @@ def get_pip_requirements_from_project_dir(
     out_requirements_path: Path | None = None,
 ) -> PipRequirements:
     if out_requirements_path is None:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt") as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete_on_close=False
+        ) as f:
             requirements_path = Path(f.name)
-            write_requirements_file_from_project_dir(
-                project_dir,
-                requirements_path,
-                extra_args=uv_args,
-            )
             requirements = PipRequirements.from_requirements_file(requirements_path)
+        write_requirements_file_from_project_dir(
+            project_dir,
+            requirements_path,
+            extra_args=uv_args,
+        )
+
     else:
         write_requirements_file_from_project_dir(
             project_dir,


### PR DESCRIPTION
in current version, uv2conda could not work properly on windows, which error log is:
```log
Output from uv: error: Failed to persist temporary file to C:\Users\UserName\AppData\Local\Temp\tmpuaezv1zl.txt: failed to persist temporary file: Access is denied. (os error 5)
```
refer https://github.com/python/cpython/issues/58451, in windows, we should close tempfile before open it again, so just changed uv.py to fix it